### PR TITLE
handle no config - turn off backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application
         android:name=".PlayBillingTesterApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Register" >

--- a/app/src/main/java/com/nytimes/android/external/playbillingtester/BillingServiceStubImpl.java
+++ b/app/src/main/java/com/nytimes/android/external/playbillingtester/BillingServiceStubImpl.java
@@ -6,11 +6,10 @@ import android.os.RemoteException;
 
 import com.google.gson.Gson;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentBundleBuilder;
-import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentToReplaceSkusBundleBuilder;
+import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.PurchasesBundleBuilder;
 import com.nytimes.android.external.playbillingtester.bundle.SkuDetailsBundleBuilder;
-import com.nytimes.android.external.playbillingtester.model.Config;
 import com.nytimes.android.external.playbillingtesterlib.GoogleUtil;
 
 import java.util.List;
@@ -20,7 +19,6 @@ import javax.inject.Inject;
 public class BillingServiceStubImpl extends IInAppBillingService.Stub {
 
     final Gson gson;
-    final Config config;
     private final APIOverrides apiOverrides;
     private final BuyIntentBundleBuilder buyIntentBundleBuilder;
     private final SkuDetailsBundleBuilder skuDetailsBundleBuilder;
@@ -29,7 +27,7 @@ public class BillingServiceStubImpl extends IInAppBillingService.Stub {
     private final BuyIntentToReplaceSkusBundleBuilder buyIntentToReplaceSkusBundleBuilder;
 
     @Inject
-    public BillingServiceStubImpl(APIOverrides apiOverrides, Gson gson, Config config,
+    public BillingServiceStubImpl(APIOverrides apiOverrides, Gson gson,
                                   BuyIntentBundleBuilder buyIntentBundleBuilder,
                                   SkuDetailsBundleBuilder skuDetailsBundleBuilder,
                                   PurchasesBundleBuilder purchasesBundleBuilder,
@@ -37,7 +35,6 @@ public class BillingServiceStubImpl extends IInAppBillingService.Stub {
                                   BuyIntentToReplaceSkusBundleBuilder buyIntentToReplaceSkusBundleBuilder) {
         this.apiOverrides = apiOverrides;
         this.gson = gson;
-        this.config = config;
         this.buyIntentBundleBuilder = buyIntentBundleBuilder;
         this.skuDetailsBundleBuilder = skuDetailsBundleBuilder;
         this.purchasesBundleBuilder = purchasesBundleBuilder;

--- a/app/src/main/java/com/nytimes/android/external/playbillingtester/bundle/SkuDetailsBundleBuilder.java
+++ b/app/src/main/java/com/nytimes/android/external/playbillingtester/bundle/SkuDetailsBundleBuilder.java
@@ -2,6 +2,7 @@ package com.nytimes.android.external.playbillingtester.bundle;
 
 import android.os.Bundle;
 
+import com.google.common.base.Optional;
 import com.google.gson.Gson;
 import com.nytimes.android.external.playbillingtester.APIOverrides;
 import com.nytimes.android.external.playbillingtester.model.Config;
@@ -17,11 +18,11 @@ import javax.inject.Inject;
 public class SkuDetailsBundleBuilder extends BaseBundleBuilder {
 
     private List<String> detailsList;
-    private final Config config;
+    private final Optional<Config> config;
     private final Gson gson;
 
     @Inject
-    public SkuDetailsBundleBuilder(APIOverrides apiOverrides, Config config, Gson gson) {
+    public SkuDetailsBundleBuilder(APIOverrides apiOverrides, Optional<Config> config, Gson gson) {
         super(apiOverrides);
         this.config = config;
         this.gson = gson;
@@ -34,14 +35,16 @@ public class SkuDetailsBundleBuilder extends BaseBundleBuilder {
     }
 
     public SkuDetailsBundleBuilder skus(List<String> skus, String type) {
-        for (String sku : skus) {
-            sku(sku, type);
+        if (config.isPresent()) {
+            for (String sku : skus) {
+                sku(sku, type);
+            }
         }
         return this;
     }
 
     private void sku(String sku, String type) {
-        ConfigSku configSku = config.skus().get(sku);
+        ConfigSku configSku = config.get().skus().get(sku);
         if (configSku != null) {
             GoogleProductResponse googleProductResponse = new GoogleProductResponse.Builder()
                     .productId(sku)

--- a/app/src/main/java/com/nytimes/android/external/playbillingtester/di/ActivityModule.java
+++ b/app/src/main/java/com/nytimes/android/external/playbillingtester/di/ActivityModule.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 
+import com.google.common.base.Optional;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.nytimes.android.external.playbillingtester.BuildConfig;
@@ -12,7 +13,6 @@ import com.nytimes.android.external.playbillingtester.GithubApi;
 import com.nytimes.android.external.playbillingtester.PermissionHandler;
 import com.nytimes.android.external.playbillingtester.R;
 import com.nytimes.android.external.playbillingtester.model.Config;
-import com.nytimes.android.external.playbillingtester.model.ImmutableConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,18 +53,18 @@ public class ActivityModule {
 
     @Provides
     @ScopeActivity
-    Config provideConfig(Gson gson) {
+    Optional<Config> provideConfig(Gson gson) {
         if (PermissionHandler.hasPermission(activity)) {
             try {
-                return gson.fromJson(Files.newReader(new File(Environment.getExternalStorageDirectory().getPath(),
-                        CONFIG_FILE), UTF_8), Config.class);
+                return Optional.of(gson.fromJson(Files.newReader(new File(
+                        Environment.getExternalStorageDirectory().getPath(), CONFIG_FILE), UTF_8), Config.class));
             } catch (FileNotFoundException exc) {
                 LOGGER.error(activity.getString(R.string.config_not_found), exc);
             }
         } else {
             PermissionHandler.requestPermission(activity);
         }
-        return ImmutableConfig.builder().build();
+        return Optional.absent();
     }
 
     @Provides

--- a/app/src/main/java/com/nytimes/android/external/playbillingtester/di/ServiceModule.java
+++ b/app/src/main/java/com/nytimes/android/external/playbillingtester/di/ServiceModule.java
@@ -5,6 +5,7 @@ import android.app.Service;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 
+import com.google.common.base.Optional;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.nytimes.android.external.playbillingtester.APIOverrides;
@@ -14,12 +15,11 @@ import com.nytimes.android.external.playbillingtester.PermissionHandler;
 import com.nytimes.android.external.playbillingtester.Purchases;
 import com.nytimes.android.external.playbillingtester.R;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentBundleBuilder;
-import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentToReplaceSkusBundleBuilder;
+import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.PurchasesBundleBuilder;
 import com.nytimes.android.external.playbillingtester.bundle.SkuDetailsBundleBuilder;
 import com.nytimes.android.external.playbillingtester.model.Config;
-import com.nytimes.android.external.playbillingtester.model.ImmutableConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,29 +51,29 @@ public class ServiceModule {
 
     @Provides
     @ScopeService
-    Config provideConfig(Gson gson) {
+    Optional<Config> provideConfig(Gson gson) {
         if (PermissionHandler.hasPermission(service)) {
             try {
-                return gson.fromJson(Files.newReader(new File(Environment.getExternalStorageDirectory().getPath(),
-                        CONFIG_FILE), UTF_8), Config.class);
+                return Optional.of(gson.fromJson(Files.newReader(new File(
+                        Environment.getExternalStorageDirectory().getPath(), CONFIG_FILE), UTF_8), Config.class));
             } catch (FileNotFoundException exc) {
                 LOGGER.error(service.getString(R.string.config_not_found), exc);
             }
         }
-        return ImmutableConfig.builder().build();
+        return Optional.absent();
     }
 
     @Provides
     @ScopeService
     IInAppBillingService.Stub provideBillingServiceStubImpl(APIOverrides apiOverrides,
-                                                            Gson gson, Config config,
+                                                            Gson gson,
                                                             BuyIntentBundleBuilder buyIntentBundleBuilder,
                                                             SkuDetailsBundleBuilder skuDetailsBundleBuilder,
                                                             PurchasesBundleBuilder purchasesBundleBuilder,
                                                             ConsumePurchaseResponse consumePurchaseResponse,
                                                             BuyIntentToReplaceSkusBundleBuilder
                                                                     buyIntentToReplaceSkusBundleBuilder) {
-        return new BillingServiceStubImpl(apiOverrides, gson, config, buyIntentBundleBuilder, skuDetailsBundleBuilder,
+        return new BillingServiceStubImpl(apiOverrides, gson, buyIntentBundleBuilder, skuDetailsBundleBuilder,
                 purchasesBundleBuilder, consumePurchaseResponse, buyIntentToReplaceSkusBundleBuilder);
     }
 
@@ -87,7 +87,7 @@ public class ServiceModule {
     @Provides
     @ScopeService
     SkuDetailsBundleBuilder provideSkuDetailsBundleBuilder(APIOverrides apiOverrides,
-                                                           Config config, Gson gson) {
+                                                           Optional<Config> config, Gson gson) {
         return new SkuDetailsBundleBuilder(apiOverrides, config, gson);
     }
 

--- a/app/src/main/res/layout/content_empty.xml
+++ b/app/src/main/res/layout/content_empty.xml
@@ -15,6 +15,7 @@
         app:srcCompat="@drawable/ic_shopping" />
 
     <TextView
+        android:id="@+id/empty_view_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/recycler_empty_title_margin_top"
@@ -25,6 +26,7 @@
         android:text="@string/empty_message_title" />
 
     <TextView
+        android:id="@+id/empty_view_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,9 +39,10 @@
     <string name="config_replace">replace()</string>
 
 
-    <string name="empty_message_text">There are no purchases available, please integrate the Register Library into your app if you haven\'t done so already.</string>
+    <string name="empty_message_text">There are no purchases available. Please integrate the Register Library into your app if you haven\'t done so already.</string>
     <string name="empty_message_title">No purchases</string>
-
+    <string name="no_config_text">There is no config file. Please push playbillingtester.json file to sdcard/, restart the app, and accept file permissions.</string>
+    <string name="no_config_title">No config file</string>
     <!-- Buy-->
     <string name="title_activity_buy">BuyActivity</string>
 

--- a/app/src/test/java/com/nytimes/android/external/playbillingtester/BillingServicesSubImplTest.java
+++ b/app/src/test/java/com/nytimes/android/external/playbillingtester/BillingServicesSubImplTest.java
@@ -5,11 +5,10 @@ import android.os.RemoteException;
 
 import com.google.common.collect.ImmutableList;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentBundleBuilder;
-import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.BuyIntentToReplaceSkusBundleBuilder;
+import com.nytimes.android.external.playbillingtester.bundle.ConsumePurchaseResponse;
 import com.nytimes.android.external.playbillingtester.bundle.PurchasesBundleBuilder;
 import com.nytimes.android.external.playbillingtester.bundle.SkuDetailsBundleBuilder;
-import com.nytimes.android.external.playbillingtester.model.Config;
 import com.nytimes.android.external.playbillingtesterlib.GoogleUtil;
 
 import org.junit.Before;
@@ -39,9 +38,6 @@ public class BillingServicesSubImplTest {
 
     @Mock
     private APIOverrides apiOverrides;
-
-    @Mock
-    private Config config;
 
     @Mock
     private BuyIntentBundleBuilder buyIntentBundleBuilder;
@@ -86,7 +82,7 @@ public class BillingServicesSubImplTest {
                 .thenReturn(buyIntentToReplaceSkusBundleBuilder);
         when(buyIntentToReplaceSkusBundleBuilder.type(anyString())).thenReturn(buyIntentToReplaceSkusBundleBuilder);
         when(buyIntentToReplaceSkusBundleBuilder.build()).thenReturn(expected);
-        testObject = new BillingServiceStubImpl(apiOverrides, create(), config,
+        testObject = new BillingServiceStubImpl(apiOverrides, create(),
                 buyIntentBundleBuilder, skuDetailsBundleBuilder, purchasesBundleBuilder,
                 mock(ConsumePurchaseResponse.class), buyIntentToReplaceSkusBundleBuilder);
     }

--- a/app/src/test/java/com/nytimes/android/external/playbillingtester/BuyActivityTest.java
+++ b/app/src/test/java/com/nytimes/android/external/playbillingtester/BuyActivityTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
@@ -115,7 +116,7 @@ public class BuyActivityTest {
         testObject.apiOverrides = apiOverrides;
         testObject.purchases = purchases;
         testObject.gson = gson;
-        testObject.config = config;
+        testObject.config = Optional.of(config);
         shadowActivity = shadowOf(testObject);
 
         when(purchases.getPurchasesLists(TYPE, CONTINUATION_TOKEN)).thenReturn(purchasesLists);

--- a/app/src/test/java/com/nytimes/android/external/playbillingtester/MainActivityTest.java
+++ b/app/src/test/java/com/nytimes/android/external/playbillingtester/MainActivityTest.java
@@ -7,7 +7,9 @@ import android.view.View;
 import android.widget.Adapter;
 import android.widget.AdapterView;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import com.nytimes.android.external.playbillingtester.model.Config;
 import com.nytimes.android.external.playbillingtesterlib.GoogleUtil;
 import com.nytimes.android.external.playbillingtesterlib.InAppPurchaseData;
 
@@ -57,6 +59,8 @@ public class MainActivityTest {
     private Purchases purchases;
     @Mock
     private APIOverridesDelegate mockApiDelegate;
+    @Mock
+    private Config config;
 
     private final InAppPurchaseData inAppPurchaseData1 = new InAppPurchaseData.Builder()
             .orderId(Long.toString(CURRENT_TIME_MS))
@@ -82,6 +86,7 @@ public class MainActivityTest {
         testObject = (MainActivity) controller.get();
         testObject.apiDelegate = mockApiDelegate;
         testObject.purchases = purchases;
+        testObject.config = Optional.of(config);
         shadowMain = Shadow.extract(testObject);
     }
 

--- a/app/src/test/java/com/nytimes/android/external/playbillingtester/bundle/ConsumePurchaseResponseTest.java
+++ b/app/src/test/java/com/nytimes/android/external/playbillingtester/bundle/ConsumePurchaseResponseTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.nytimes.android.external.playbillingtester.APIOverrides;
 import com.nytimes.android.external.playbillingtester.BillingServiceStubImpl;
 import com.nytimes.android.external.playbillingtester.Purchases;
-import com.nytimes.android.external.playbillingtester.model.Config;
 import com.nytimes.android.external.playbillingtesterlib.GoogleUtil;
 
 import org.junit.Before;
@@ -44,9 +43,6 @@ public class ConsumePurchaseResponseTest {
     private Purchases.PurchasesLists subscriptionsPurchasesLists;
 
     @Mock
-    private Config config;
-
-    @Mock
     private BuyIntentBundleBuilder buyIntentBundleBuilder;
 
     @Mock
@@ -80,7 +76,7 @@ public class ConsumePurchaseResponseTest {
         when(purchasesBundleBuilder.continuationToken(anyString())).thenReturn(purchasesBundleBuilder);
         when(purchasesBundleBuilder.build()).thenReturn(expected);
         ConsumePurchaseResponse consumePurchaseResponse = new ConsumePurchaseResponse(apiOverrides, purchases);
-        testObject = new BillingServiceStubImpl(apiOverrides, create(), config,
+        testObject = new BillingServiceStubImpl(apiOverrides, create(),
                 buyIntentBundleBuilder, skuDetailsBundleBuilder, purchasesBundleBuilder, consumePurchaseResponse,
                 buyIntentToReplaceSkusBundleBuilder);
     }

--- a/app/src/test/java/com/nytimes/android/external/playbillingtester/bundle/SkuDetailsBundleBuilderTest.java
+++ b/app/src/test/java/com/nytimes/android/external/playbillingtester/bundle/SkuDetailsBundleBuilderTest.java
@@ -2,6 +2,7 @@ package com.nytimes.android.external.playbillingtester.bundle;
 
 import android.os.Bundle;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.nytimes.android.external.playbillingtester.APIOverrides;
@@ -47,7 +48,7 @@ public class SkuDetailsBundleBuilderTest {
         String title = "caps for sale";
         String price = "1.98";
 
-        testObject = new SkuDetailsBundleBuilder(apiOverrides, config, create());
+        testObject = new SkuDetailsBundleBuilder(apiOverrides, Optional.of(config), create());
         when(config.skus()).thenReturn(new ImmutableMap.Builder<String, ConfigSku>()
                 .put(SKU1, ImmutableConfigSku.builder()
                         .itemType(TYPE)


### PR DESCRIPTION
1. fixes missing permission prompt
2. when permissions have been denied, or there is no config file, app empty screen text changes to "no config".  also, buy activity text changes to "no config"
3. turn off auto backup