### PR TITLE
Remove Retrolambda from the build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion versions.compileSdk
@@ -74,7 +73,6 @@ dependencies {
         exclude module: 'guava'
     }
     testCompile libraries.javaxInject
-    retrolambdaConfig libraries.retrolambda
 }
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -11,31 +11,24 @@ buildscript {
         maven {
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
         }
-
+        google()
         jcenter()
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta2'
-        classpath 'me.tatarka:gradle-retrolambda:3.6.1'
-        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
     }
-    // this corresponds to the lombok.ast included above. fixes lint for retro-lambda
-    configurations.classpath.exclude group: 'com.android.tools.com.nytimes.android.external.lombok'
 
 }
 
 allprojects {
-    buildscript {
-
-    }
-
     repositories {
         maven {
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
         }
         mavenCentral()
+        google()
     }
 
     // Workaround to prevent Gradle from stealing focus from other apps during tests run/etc.

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -20,17 +20,16 @@ allprojects {
 ext.versions = [
         minSdk               : 16,
         targetSdk            : 25,
-        compileSdk           : 25,
-        buildTools           : '26.0.0-beta2',
+        compileSdk           : 26,
+        buildTools           : '26.0.1',
 
         // UI libs.
-        supportLibs          : '25.4.0',
-        constraint           : '1.0.2',
+        supportLibs          : '26.0.1',
+        constraint           : '1.1.0-beta1',
         butterKnife          : '8.5.1',
         swipeLayout          : '1.2.0@aar',
 
         // Others.
-        retrolambda          : '2.3.0',
         dagger               : '2.9',
         gson                 : '2.6.2',
         guava                : '19.0',
@@ -62,7 +61,6 @@ ext.libraries = [
         swipeLayout             : "com.daimajia.swipelayout:library:$versions.swipeLayout",
 
         // Others.
-        retrolambda             : "net.orfjackal.retrolambda:retrolambda:$versions.retrolambda",
         dagger                  : "com.google.dagger:dagger:$versions.dagger",
         daggerCompiler          : "com.google.dagger:dagger-compiler:$versions.dagger",
         gson                    : "com.google.code.gson:gson:$versions.gson",

--- a/sampleApp/build.gradle
+++ b/sampleApp/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion versions.compileSdk
@@ -53,7 +52,6 @@ dependencies {
     testCompile(libraries.robolectric) {
         exclude module: 'guava'
     }
-    retrolambdaConfig libraries.retrolambda
 }
 
 apply from: rootProject.file("gradle/checkstyle.gradle")


### PR DESCRIPTION
Upgrades Gradle plugin and removes Retrolambda from the build, as we can use the new Android lambda stuff