### PR TITLE
Return item type as ‘type’

### DIFF
--- a/app/src/test/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilderTest.java
+++ b/app/src/test/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilderTest.java
@@ -84,12 +84,12 @@ public class SkuDetailsBundleBuilderTest {
         ArrayList<String> detailsList =  bundle.getStringArrayList(GoogleUtil.DETAILS_LIST);
         try {
             JSONAssert.assertEquals(detailsList.get(0),
-                    "{\"itemType\":\"subs\",\"productId\":\"sku1\",\"price\":\"$1.98\"," +
+                    "{\"type\":\"subs\",\"productId\":\"sku1\",\"price\":\"$1.98\"," +
                             "\"description\":\"some description\",\"title\":\"caps for sale\"," +
                             "\"price_amount_micros\":1980000,\"price_currency_code\":\"USD\"}",
                     JSONCompareMode.LENIENT);
             JSONAssert.assertEquals(detailsList.get(1),
-                    "{\"itemType\":\"subs\",\"productId\":\"sku2\",\"price\":\"$1.98\"," +
+                    "{\"type\":\"subs\",\"productId\":\"sku2\",\"price\":\"$1.98\"," +
                             "\"description\":\"some description\",\"title\":\"caps for sale\"," +
                             "\"price_amount_micros\":1980000,\"price_currency_code\":\"USD\"}",
                     JSONCompareMode.LENIENT);

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
@@ -14,7 +14,7 @@ import static com.nytimes.android.external.registerlib.JsonHelper.getFieldAsStri
 public class GoogleProductResponse {
     private static final String TAG = GoogleProductResponse.class.getSimpleName();
     private static final String FLD_PRODUCT_ID = "productId";
-    private static final String FLD_ITEM_TYPE = "itemType";
+    private static final String FLD_ITEM_TYPE = "type";
     private static final String FLD_PRICE = "price";
     private static final String FLD_TITLE = "title";
     private static final String FLD_DESCRIPTION = "description";


### PR DESCRIPTION
According to the reference, the correct field name for the item type is ‘type’

See https://developer.android.com/google/play/billing/billing_reference