### PR TITLE
Add missing `GoogleProductResponse` fields

### DIFF
--- a/app/src/main/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilder.java
+++ b/app/src/main/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilder.java
@@ -43,15 +43,25 @@ public class SkuDetailsBundleBuilder extends BaseBundleBuilder {
     private void sku(String sku, String type) {
         ConfigSku configSku = config.get().skus().get(sku);
         if (configSku != null) {
-            GoogleProductResponse googleProductResponse = new GoogleProductResponse.Builder()
+            GoogleProductResponse.Builder builder = new GoogleProductResponse.Builder()
                     .productId(sku)
                     .itemType(type)
                     .description(configSku.description())
                     .title(configSku.title())
                     .price("$" + configSku.price())
                     .priceAmountMicros((int) (Double.parseDouble(configSku.price()) * 1000000))
-                    .priceCurrencyCode("USD")
-                    .build();
+                    .subscriptionPeriod(configSku.subscriptionPeriod())
+                    .freeTrialPeriod(configSku.freeTrialPeriod())
+                    .priceCurrencyCode("USD");
+
+            if (configSku.introductoryPrice() != null) {
+                builder.introductoryPrice("$" + configSku.introductoryPrice())
+                        .introductoryPriceMicros((int) (Double.parseDouble(configSku.introductoryPrice()) * 1000000))
+                        .introductoryPriceCycles(configSku.introductoryPriceCycles())
+                        .introductoryPricePeriod(configSku.introductoryPricePeriod());
+            }
+
+            GoogleProductResponse googleProductResponse = builder.build();
             detailsList.add(GoogleProductResponse.toJson(googleProductResponse));
         }
     }

--- a/app/src/main/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilder.java
+++ b/app/src/main/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilder.java
@@ -56,7 +56,8 @@ public class SkuDetailsBundleBuilder extends BaseBundleBuilder {
 
             if (configSku.introductoryPrice() != null) {
                 builder.introductoryPrice("$" + configSku.introductoryPrice())
-                        .introductoryPriceMicros((int) (Double.parseDouble(configSku.introductoryPrice()) * 1000000))
+                        .introductoryPriceAmountMicros((int) (Double.parseDouble(configSku
+                                .introductoryPrice()) * 1000000))
                         .introductoryPriceCycles(configSku.introductoryPriceCycles())
                         .introductoryPricePeriod(configSku.introductoryPricePeriod());
             }

--- a/app/src/main/java/com/nytimes/android/external/register/model/ConfigSku.java
+++ b/app/src/main/java/com/nytimes/android/external/register/model/ConfigSku.java
@@ -16,8 +16,9 @@ public abstract class ConfigSku {
     public abstract String title();
     public abstract String description();
 
+    @Value.Default
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    @Value.Default public int introductoryPriceCycles() {
+    public int introductoryPriceCycles() {
         return 0;
     }
 

--- a/app/src/main/java/com/nytimes/android/external/register/model/ConfigSku.java
+++ b/app/src/main/java/com/nytimes/android/external/register/model/ConfigSku.java
@@ -1,5 +1,7 @@
 package com.nytimes.android.external.register.model;
 
+import android.support.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.immutables.gson.Gson;
@@ -7,11 +9,26 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Gson.TypeAdapters
-public interface ConfigSku {
-    String type();
-    String price();
-    String title();
-    String description();
+public abstract class ConfigSku {
+
+    public abstract String type();
+    public abstract String price();
+    public abstract String title();
+    public abstract String description();
+
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    @Value.Default public int introductoryPriceCycles() {
+        return 0;
+    }
+
+    @Nullable
+    public abstract String freeTrialPeriod();
     @SerializedName("package")
-    String packageName();
+    public abstract String packageName();
+    @Nullable
+    public abstract String introductoryPrice();
+    @Nullable
+    public abstract String introductoryPricePeriod();
+    @Nullable
+    public abstract String subscriptionPeriod();
 }

--- a/app/src/test/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilderTest.java
+++ b/app/src/test/java/com/nytimes/android/external/register/bundle/SkuDetailsBundleBuilderTest.java
@@ -83,15 +83,17 @@ public class SkuDetailsBundleBuilderTest {
                 .isEqualTo(GoogleUtil.RESULT_OK);
         ArrayList<String> detailsList =  bundle.getStringArrayList(GoogleUtil.DETAILS_LIST);
         try {
-            JSONAssert.assertEquals(detailsList.get(0),
+            JSONAssert.assertEquals(
                     "{\"type\":\"subs\",\"productId\":\"sku1\",\"price\":\"$1.98\"," +
                             "\"description\":\"some description\",\"title\":\"caps for sale\"," +
                             "\"price_amount_micros\":1980000,\"price_currency_code\":\"USD\"}",
+                    detailsList.get(0),
                     JSONCompareMode.LENIENT);
-            JSONAssert.assertEquals(detailsList.get(1),
+            JSONAssert.assertEquals(
                     "{\"type\":\"subs\",\"productId\":\"sku2\",\"price\":\"$1.98\"," +
                             "\"description\":\"some description\",\"title\":\"caps for sale\"," +
                             "\"price_amount_micros\":1980000,\"price_currency_code\":\"USD\"}",
+                    detailsList.get(1),
                     JSONCompareMode.LENIENT);
         } catch (JSONException e) {
            throw  Exceptions.propagate(e);

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,6 +24,8 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     testImplementation libraries.junit
+    testImplementation libraries.assertJ
+    androidTestImplementation libraries.assertJ
 }
 
 buildscript {

--- a/lib/src/androidTestDebug/java/com/nytimes/android/external/registerlib/GoogleProductResponseTest.java
+++ b/lib/src/androidTestDebug/java/com/nytimes/android/external/registerlib/GoogleProductResponseTest.java
@@ -4,36 +4,36 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class GoogleProductResponseTest {
 
-
     @Test
     public void testGoodString(){
-
-        String json2 = "{ \"description\": " +
-                "\"Unlimited article access, anytime, anywhere. Save with an annual subscription.\", " +
-                "\"introductoryPrice\": \"$89.99\", \"introductoryPriceCycles\": 1, " +
-                "\"introductoryPriceMicros\": 89990000, " +
+        String goodJSONSample = "{ \"description\": " +
+                "\"Buy now!!\", " +
+                "\"introductoryPrice\": \"$79.99\", \"introductoryPriceCycles\": 1, " +
+                "\"introductoryPriceMicros\": 79990000, " +
                 "\"introductoryPricePeriod\": \"P1Y\", \"price\": \"$129.99\", \"price_amount_micros\": 129990000, " +
-                "\"price_currency_code\": \"USD\", \"productId\": \"com.nytimes.googleplay.bundle.xpass.v1.yearly\", " +
-                "\"subscriptionPeriod\": \"P1Y\", \"title\": \"NYT Basic Access: Annual\", \"type\": \"subs\" }";
-        GoogleProductResponse response = GoogleProductResponse.fromJson(json2);
-        assertNotNull(response);
+                "\"price_currency_code\": \"USD\", \"productId\": \"com.somecompany.googleplay.bundle.yearly\", " +
+                "\"subscriptionPeriod\": \"P1Y\", \"title\": \"Yearly Option\", \"type\": \"subs\" }";
+        GoogleProductResponse response = GoogleProductResponse.fromJson(goodJSONSample);
+        assertThat(response).isNotNull();
     }
-    @Test
-    public void testBadString(){
-        String bad = "{ \"description\": " +
-                "\"Basic access features, plus NYT Crossword, Cooking, and one bonus \\nsubscription.\", " +
-                "\"freeTrialPeriod\": \"P1W\", \"price\": \"$24.99\", \"price_amount_micros\": 24990000, " +
-                "\"price_currency_code\": \"USD\", " +
-                "\"productId\": \"com.nytimes.googleplay.bundle.maxadacr.v1.monthly\", " +
-                "\"subscriptionPeriod\": \"P1M\", " +
-                "\"title\": \"NYT All Access (NYTimes - Latest News)\", \"type\": \"subs\" }";
 
-        GoogleProductResponse response = GoogleProductResponse.fromJson(bad);
-        assertNotNull(response);
+    @Test
+    public void testMissingIntField(){
+        String jsonMissingFields = "{ \"description\": " +
+                "\"Basic access , " +
+                "\"freeTrialPeriod\": \"P1W\", \"price\": \"$34.99\", \"price_amount_micros\": 34990000, " +
+                "\"price_currency_code\": \"USD\", " +
+                "\"productId\": \"com.somecompany.googleplay.bundle.monthly\", " +
+                "\"subscriptionPeriod\": \"P1M\", " +
+                "\"title\": \"Premium Access\", \"type\": \"subs\" }";
+
+        GoogleProductResponse response = GoogleProductResponse.fromJson(jsonMissingFields);
+        assertThat(response).isNotNull();
     }
 
     @Test
@@ -42,9 +42,9 @@ public class GoogleProductResponseTest {
         Integer field = JsonHelper.getFieldAsIntOrNull(obj, "missingField");
         Integer foundField = JsonHelper.getFieldAsIntOrNull(obj, "myint");
 
-        assertNull(field);
-        assertNotNull(foundField);
-        assertEquals(2, foundField.intValue());
+        assertThat(field).isNull();
+        assertThat(foundField).isNotNull();
+        assertThat(foundField.intValue()).isEqualTo(2);
     }
 
 }

--- a/lib/src/androidTestDebug/java/com/nytimes/android/external/registerlib/GoogleProductResponseTest.java
+++ b/lib/src/androidTestDebug/java/com/nytimes/android/external/registerlib/GoogleProductResponseTest.java
@@ -1,0 +1,50 @@
+package com.nytimes.android.external.registerlib;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GoogleProductResponseTest {
+
+
+    @Test
+    public void testGoodString(){
+
+        String json2 = "{ \"description\": " +
+                "\"Unlimited article access, anytime, anywhere. Save with an annual subscription.\", " +
+                "\"introductoryPrice\": \"$89.99\", \"introductoryPriceCycles\": 1, " +
+                "\"introductoryPriceMicros\": 89990000, " +
+                "\"introductoryPricePeriod\": \"P1Y\", \"price\": \"$129.99\", \"price_amount_micros\": 129990000, " +
+                "\"price_currency_code\": \"USD\", \"productId\": \"com.nytimes.googleplay.bundle.xpass.v1.yearly\", " +
+                "\"subscriptionPeriod\": \"P1Y\", \"title\": \"NYT Basic Access: Annual\", \"type\": \"subs\" }";
+        GoogleProductResponse response = GoogleProductResponse.fromJson(json2);
+        assertNotNull(response);
+    }
+    @Test
+    public void testBadString(){
+        String bad = "{ \"description\": " +
+                "\"Basic access features, plus NYT Crossword, Cooking, and one bonus \\nsubscription.\", " +
+                "\"freeTrialPeriod\": \"P1W\", \"price\": \"$24.99\", \"price_amount_micros\": 24990000, " +
+                "\"price_currency_code\": \"USD\", " +
+                "\"productId\": \"com.nytimes.googleplay.bundle.maxadacr.v1.monthly\", " +
+                "\"subscriptionPeriod\": \"P1M\", " +
+                "\"title\": \"NYT All Access (NYTimes - Latest News)\", \"type\": \"subs\" }";
+
+        GoogleProductResponse response = GoogleProductResponse.fromJson(bad);
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testNullInt() throws JSONException {
+        JSONObject obj = new JSONObject("{\"hello\": \"world\", \"myint\": 2}");
+        Integer field = JsonHelper.getFieldAsIntOrNull(obj, "missingField");
+        Integer foundField = JsonHelper.getFieldAsIntOrNull(obj, "myint");
+
+        assertNull(field);
+        assertNotNull(foundField);
+        assertEquals(2, foundField.intValue());
+    }
+
+}

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
@@ -7,7 +7,8 @@ import org.json.JSONObject;
 
 import static com.nytimes.android.external.registerlib.JsonHelper.addToObj;
 import static com.nytimes.android.external.registerlib.JsonHelper.addToObjIfNotNull;
-import static com.nytimes.android.external.registerlib.JsonHelper.getFieldAsIntOrNull;
+import static com.nytimes.android.external.registerlib.JsonHelper.getFieldAsIntOrZero;
+import static com.nytimes.android.external.registerlib.JsonHelper.getFieldAsLongOrZero;
 import static com.nytimes.android.external.registerlib.JsonHelper.getFieldAsStringOrNull;
 
 @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
@@ -23,7 +24,7 @@ public class GoogleProductResponse {
     private static final String FLD_SUBSCRIPTION_PERIOD = "subscriptionPeriod";
     private static final String FLD_FREE_TRIAL_PERIOD = "freeTrialPeriod";
     private static final String FLD_INTRODUCTORY_PRICE = "introductoryPrice";
-    private static final String FLD_INTRODUCTORY_PRICE_MICROS = "introductoryPriceMicros";
+    private static final String FLD_INTRODUCTORY_PRICE_AMT_MICROS = "introductoryPriceAmountMicros";
     private static final String FLD_INTRODUCTORY_PRICE_PERIOD = "introductoryPricePeriod";
     private static final String FLD_INTRODUCTORY_PRICE_CYCLES = "introductoryPriceCycles";
 
@@ -32,12 +33,12 @@ public class GoogleProductResponse {
     String price;
     String title;
     String description;
-    Integer priceAmountMicros;
+    long priceAmountMicros;
     String priceCurrencyCode;
     String subscriptionPeriod;
     String freeTrialPeriod;
     String introductoryPrice;
-    Integer introductoryPriceMicros;
+    long introductoryPriceAmountMicros;
     String introductoryPricePeriod;
     Integer introductoryPriceCycles;
 
@@ -54,14 +55,14 @@ public class GoogleProductResponse {
                 .price(getFieldAsStringOrNull(obj, FLD_PRICE))
                 .title(getFieldAsStringOrNull(obj, FLD_TITLE))
                 .description(getFieldAsStringOrNull(obj, FLD_DESCRIPTION))
-                .priceAmountMicros(getFieldAsIntOrNull(obj, FLD_PRICE_AMT_MICROS))
+                .priceAmountMicros(getFieldAsLongOrZero(obj, FLD_PRICE_AMT_MICROS))
                 .priceCurrencyCode(getFieldAsStringOrNull(obj, FLD_PRICE_CURR_CODE))
                 .subscriptionPeriod(getFieldAsStringOrNull(obj, FLD_SUBSCRIPTION_PERIOD))
                 .freeTrialPeriod(getFieldAsStringOrNull(obj, FLD_FREE_TRIAL_PERIOD))
                 .introductoryPrice(getFieldAsStringOrNull(obj, FLD_INTRODUCTORY_PRICE))
-                .introductoryPriceMicros(getFieldAsIntOrNull(obj, FLD_INTRODUCTORY_PRICE_MICROS))
+                .introductoryPriceAmountMicros(getFieldAsLongOrZero(obj, FLD_INTRODUCTORY_PRICE_AMT_MICROS))
                 .introductoryPricePeriod(getFieldAsStringOrNull(obj, FLD_INTRODUCTORY_PRICE_PERIOD))
-                .introductoryPriceCycles(getFieldAsIntOrNull(obj, FLD_INTRODUCTORY_PRICE_CYCLES))
+                .introductoryPriceCycles(getFieldAsIntOrZero(obj, FLD_INTRODUCTORY_PRICE_CYCLES))
                 .build();
     }
 
@@ -77,7 +78,7 @@ public class GoogleProductResponse {
         addToObjIfNotNull(FLD_SUBSCRIPTION_PERIOD, googleProductResponse.subscriptionPeriod(), obj);
         addToObjIfNotNull(FLD_FREE_TRIAL_PERIOD, googleProductResponse.freeTrialPeriod(), obj);
         addToObjIfNotNull(FLD_INTRODUCTORY_PRICE, googleProductResponse.introductoryPrice(), obj);
-        addToObj(FLD_INTRODUCTORY_PRICE_MICROS, googleProductResponse.introductoryPriceMicros(), obj);
+        addToObj(FLD_INTRODUCTORY_PRICE_AMT_MICROS, googleProductResponse.introductoryPriceAmountMicros(), obj);
         addToObjIfNotNull(FLD_INTRODUCTORY_PRICE_PERIOD, googleProductResponse.introductoryPricePeriod(), obj);
         addToObj(FLD_INTRODUCTORY_PRICE_CYCLES, googleProductResponse.introductoryPriceCycles(), obj);
         return obj.toString();
@@ -114,7 +115,7 @@ public class GoogleProductResponse {
             return this;
         }
 
-        public Builder priceAmountMicros(Integer priceAmountMicros) {
+        public Builder priceAmountMicros(long priceAmountMicros) {
             builderObject.priceAmountMicros = priceAmountMicros;
             return this;
         }
@@ -139,8 +140,8 @@ public class GoogleProductResponse {
             return this;
         }
 
-        public Builder introductoryPriceMicros(Integer introductoryPriceMicros) {
-            builderObject.introductoryPriceMicros = introductoryPriceMicros;
+        public Builder introductoryPriceAmountMicros(long introductoryPriceAmountMicros) {
+            builderObject.introductoryPriceAmountMicros = introductoryPriceAmountMicros;
             return this;
         }
 
@@ -181,7 +182,7 @@ public class GoogleProductResponse {
         return description;
     }
 
-    public Integer priceAmountMicros() {
+    public long priceAmountMicros() {
         return priceAmountMicros;
     }
 
@@ -201,8 +202,8 @@ public class GoogleProductResponse {
         return introductoryPrice;
     }
 
-    public Integer introductoryPriceMicros() {
-        return introductoryPriceMicros;
+    public long introductoryPriceAmountMicros() {
+        return introductoryPriceAmountMicros;
     }
 
     public String introductoryPricePeriod() {

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
@@ -32,14 +32,14 @@ public class GoogleProductResponse {
     String price;
     String title;
     String description;
-    int priceAmountMicros;
+    Integer priceAmountMicros;
     String priceCurrencyCode;
     String subscriptionPeriod;
     String freeTrialPeriod;
     String introductoryPrice;
-    int introductoryPriceMicros;
+    Integer introductoryPriceMicros;
     String introductoryPricePeriod;
-    int introductoryPriceCycles;
+    Integer introductoryPriceCycles;
 
     public static GoogleProductResponse fromJson(String json) {
         JSONObject obj = null;
@@ -114,7 +114,7 @@ public class GoogleProductResponse {
             return this;
         }
 
-        public Builder priceAmountMicros(int priceAmountMicros) {
+        public Builder priceAmountMicros(Integer priceAmountMicros) {
             builderObject.priceAmountMicros = priceAmountMicros;
             return this;
         }
@@ -139,7 +139,7 @@ public class GoogleProductResponse {
             return this;
         }
 
-        public Builder introductoryPriceMicros(int introductoryPriceMicros) {
+        public Builder introductoryPriceMicros(Integer introductoryPriceMicros) {
             builderObject.introductoryPriceMicros = introductoryPriceMicros;
             return this;
         }
@@ -149,7 +149,7 @@ public class GoogleProductResponse {
             return this;
         }
 
-        public Builder introductoryPriceCycles(int introductoryPriceCycles) {
+        public Builder introductoryPriceCycles(Integer introductoryPriceCycles) {
             builderObject.introductoryPriceCycles = introductoryPriceCycles;
             return this;
         }
@@ -181,7 +181,7 @@ public class GoogleProductResponse {
         return description;
     }
 
-    public int priceAmountMicros() {
+    public Integer priceAmountMicros() {
         return priceAmountMicros;
     }
 
@@ -201,7 +201,7 @@ public class GoogleProductResponse {
         return introductoryPrice;
     }
 
-    public int introductoryPriceMicros() {
+    public Integer introductoryPriceMicros() {
         return introductoryPriceMicros;
     }
 
@@ -209,7 +209,7 @@ public class GoogleProductResponse {
         return introductoryPricePeriod;
     }
 
-    public int introductoryPriceCycles() {
+    public Integer introductoryPriceCycles() {
         return introductoryPriceCycles;
     }
 }

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleProductResponse.java
@@ -20,6 +20,12 @@ public class GoogleProductResponse {
     private static final String FLD_DESCRIPTION = "description";
     private static final String FLD_PRICE_AMT_MICROS = "price_amount_micros";
     private static final String FLD_PRICE_CURR_CODE = "price_currency_code";
+    private static final String FLD_SUBSCRIPTION_PERIOD = "subscriptionPeriod";
+    private static final String FLD_FREE_TRIAL_PERIOD = "freeTrialPeriod";
+    private static final String FLD_INTRODUCTORY_PRICE = "introductoryPrice";
+    private static final String FLD_INTRODUCTORY_PRICE_MICROS = "introductoryPriceMicros";
+    private static final String FLD_INTRODUCTORY_PRICE_PERIOD = "introductoryPricePeriod";
+    private static final String FLD_INTRODUCTORY_PRICE_CYCLES = "introductoryPriceCycles";
 
     String productId;
     String itemType;
@@ -28,6 +34,12 @@ public class GoogleProductResponse {
     String description;
     int priceAmountMicros;
     String priceCurrencyCode;
+    String subscriptionPeriod;
+    String freeTrialPeriod;
+    String introductoryPrice;
+    int introductoryPriceMicros;
+    String introductoryPricePeriod;
+    int introductoryPriceCycles;
 
     public static GoogleProductResponse fromJson(String json) {
         JSONObject obj = null;
@@ -44,6 +56,12 @@ public class GoogleProductResponse {
                 .description(getFieldAsStringOrNull(obj, FLD_DESCRIPTION))
                 .priceAmountMicros(getFieldAsIntOrNull(obj, FLD_PRICE_AMT_MICROS))
                 .priceCurrencyCode(getFieldAsStringOrNull(obj, FLD_PRICE_CURR_CODE))
+                .subscriptionPeriod(getFieldAsStringOrNull(obj, FLD_SUBSCRIPTION_PERIOD))
+                .freeTrialPeriod(getFieldAsStringOrNull(obj, FLD_FREE_TRIAL_PERIOD))
+                .introductoryPrice(getFieldAsStringOrNull(obj, FLD_INTRODUCTORY_PRICE))
+                .introductoryPriceMicros(getFieldAsIntOrNull(obj, FLD_INTRODUCTORY_PRICE_MICROS))
+                .introductoryPricePeriod(getFieldAsStringOrNull(obj, FLD_INTRODUCTORY_PRICE_PERIOD))
+                .introductoryPriceCycles(getFieldAsIntOrNull(obj, FLD_INTRODUCTORY_PRICE_CYCLES))
                 .build();
     }
 
@@ -56,6 +74,12 @@ public class GoogleProductResponse {
         addToObjIfNotNull(FLD_DESCRIPTION, googleProductResponse.description(), obj);
         addToObj(FLD_PRICE_AMT_MICROS, googleProductResponse.priceAmountMicros(), obj);
         addToObjIfNotNull(FLD_PRICE_CURR_CODE, googleProductResponse.priceCurrencyCode(), obj);
+        addToObjIfNotNull(FLD_SUBSCRIPTION_PERIOD, googleProductResponse.subscriptionPeriod(), obj);
+        addToObjIfNotNull(FLD_FREE_TRIAL_PERIOD, googleProductResponse.freeTrialPeriod(), obj);
+        addToObjIfNotNull(FLD_INTRODUCTORY_PRICE, googleProductResponse.introductoryPrice(), obj);
+        addToObj(FLD_INTRODUCTORY_PRICE_MICROS, googleProductResponse.introductoryPriceMicros(), obj);
+        addToObjIfNotNull(FLD_INTRODUCTORY_PRICE_PERIOD, googleProductResponse.introductoryPricePeriod(), obj);
+        addToObj(FLD_INTRODUCTORY_PRICE_CYCLES, googleProductResponse.introductoryPriceCycles(), obj);
         return obj.toString();
     }
 
@@ -100,6 +124,36 @@ public class GoogleProductResponse {
             return this;
         }
 
+        public Builder subscriptionPeriod(String subscriptionPeriod) {
+            builderObject.subscriptionPeriod = subscriptionPeriod;
+            return this;
+        }
+
+        public Builder freeTrialPeriod(String freeTrialPeriod) {
+            builderObject.freeTrialPeriod = freeTrialPeriod;
+            return this;
+        }
+
+        public Builder introductoryPrice(String introductoryPrice) {
+            builderObject.introductoryPrice = introductoryPrice;
+            return this;
+        }
+
+        public Builder introductoryPriceMicros(int introductoryPriceMicros) {
+            builderObject.introductoryPriceMicros = introductoryPriceMicros;
+            return this;
+        }
+
+        public Builder introductoryPricePeriod(String introductoryPricePeriod) {
+            builderObject.introductoryPricePeriod = introductoryPricePeriod;
+            return this;
+        }
+
+        public Builder introductoryPriceCycles(int introductoryPriceCycles) {
+            builderObject.introductoryPriceCycles = introductoryPriceCycles;
+            return this;
+        }
+
         public GoogleProductResponse build() {
             return builderObject;
         }
@@ -133,5 +187,29 @@ public class GoogleProductResponse {
 
     public String priceCurrencyCode() {
         return priceCurrencyCode;
+    }
+
+    public String subscriptionPeriod() {
+        return subscriptionPeriod;
+    }
+
+    public String freeTrialPeriod() {
+        return freeTrialPeriod;
+    }
+
+    public String introductoryPrice() {
+        return introductoryPrice;
+    }
+
+    public int introductoryPriceMicros() {
+        return introductoryPriceMicros;
+    }
+
+    public String introductoryPricePeriod() {
+        return introductoryPricePeriod;
+    }
+
+    public int introductoryPriceCycles() {
+        return introductoryPriceCycles;
     }
 }

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/JsonHelper.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/JsonHelper.java
@@ -13,27 +13,15 @@ public final class JsonHelper {
     }
 
     public static String getFieldAsStringOrNull(JSONObject obj, String field) {
-        String ret = null;
-        if (obj != null) {
-            try {
-                ret = obj.getString(field);
-            } catch (JSONException exc) {
-                Log.e(TAG, "Error getting String " + field, exc);
-            }
-        }
-        return ret;
+        return (obj == null) ? null : obj.optString(field, null);
     }
 
-    public static Integer getFieldAsIntOrNull(JSONObject obj, String field) {
-        Integer ret = null;
-        if (obj != null) {
-            try {
-                ret = obj.getInt(field);
-            } catch (JSONException exc) {
-                Log.e(TAG, "Error getting Int " + field, exc);
-            }
-        }
-        return ret;
+    public static int getFieldAsIntOrZero(JSONObject obj, String field) {
+        return (obj == null) ? 0 : obj.optInt(field);
+    }
+
+    public static long getFieldAsLongOrZero(JSONObject obj, String field) {
+        return (obj == null) ? 0L : obj.optLong(field);
     }
 
     public static void addToObjIfNotNull(String field, String val, JSONObject obj) {
@@ -47,6 +35,14 @@ public final class JsonHelper {
     }
 
     public static void addToObj(String field, Integer val, JSONObject obj) {
+        try {
+            obj.put(field, val);
+        } catch (JSONException exc) {
+            Log.e(TAG, "Error putting " + field + "," + val, exc);
+        }
+    }
+
+    public static void addToObj(String field, long val, JSONObject obj) {
         try {
             obj.put(field, val);
         } catch (JSONException exc) {

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/JsonHelper.java
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/JsonHelper.java
@@ -46,7 +46,7 @@ public final class JsonHelper {
         }
     }
 
-    public static void addToObj(String field, int val, JSONObject obj) {
+    public static void addToObj(String field, Integer val, JSONObject obj) {
         try {
             obj.put(field, val);
         } catch (JSONException exc) {

--- a/sampleApp/register.json
+++ b/sampleApp/register.json
@@ -12,7 +12,8 @@
 			"price" : "10.00",
 			"title" : "Sample Subscription Item1",
 			"description" : "This is a subscription item for use with Register sample app",
-			"package" : "com.nytimes.android.external.register"
+			"package" : "com.nytimes.android.external.register",
+			"introductoryPrice" : "9.00"
 		}
 	},
 	"users": [

--- a/sampleApp/src/main/java/com/nytimes/android/external/register/sample/SampleAdapter.java
+++ b/sampleApp/src/main/java/com/nytimes/android/external/register/sample/SampleAdapter.java
@@ -59,7 +59,7 @@ public class SampleAdapter extends RecyclerView.Adapter<SampleAdapter.SampleView
 
         holder.title.setText(item.getTitle());
         holder.description.setText(item.getDescription());
-        holder.button.setText(isPurchased ? context.getString(R.string.purchased) : item.getPrice());
+        holder.button.setText(getButtonText(isPurchased, context.getString(R.string.purchased), item));
         holder.button.setEnabled(!isPurchased);
         ViewCompat.setBackgroundTintList(holder.button, prefsManager.isUsingTestGoogleServiceProvider() ?
                 colorTesterEnbeled : colorTesterDisabled);
@@ -105,6 +105,11 @@ public class SampleAdapter extends RecyclerView.Adapter<SampleAdapter.SampleView
         inflater = null;
         purchasesMap.clear();
         items.clear();
+    }
+
+    private String getButtonText(boolean isPurchased, String purchasedText, SkuDetails item) {
+        return isPurchased ? purchasedText : item.getIntroductoryPrice() == null ?
+                item.getPrice() : item.getIntroductoryPrice() + "(" + item.getPrice() + ")";
     }
 
     static class SampleViewHolder extends RecyclerView.ViewHolder {


### PR DESCRIPTION
This PR adds fields that previously weren't being returned by Register:

* `subscriptionPeriod`
* `freeTrialPeriod`
* `introductoryPrice`
* `introductoryPriceMicros`
* `introductoryPricePeriod`
* `introductoryPriceCycles`