### PR TITLE
Fixes Nullablity issues due to Kotlin Conversion

### DIFF
--- a/app/src/main/java/com/nytimes/android/external/register/BillingServiceStubImpl.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/BillingServiceStubImpl.kt
@@ -34,7 +34,7 @@ constructor(private val apiOverrides: APIOverrides,
     }
 
     override fun getBuyIntent(apiVersion: Int, packageName: String, sku: String, type: String,
-                              developerPayload: String): Bundle {
+                              developerPayload: String?): Bundle {
         return buyIntentBundleBuilder
                 .newBuilder()
                 .packageName(packageName)
@@ -44,7 +44,7 @@ constructor(private val apiOverrides: APIOverrides,
                 .build()
     }
 
-    override fun getPurchases(apiVersion: Int, packageName: String, type: String, continuationToken: String): Bundle {
+    override fun getPurchases(apiVersion: Int, packageName: String, type: String, continuationToken: String?): Bundle {
         return purchasesBundleBuilder
                 .newBuilder()
                 .type(type)

--- a/app/src/main/java/com/nytimes/android/external/register/OptionalExt.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/OptionalExt.kt
@@ -1,0 +1,11 @@
+package com.nytimes.android.external.register
+
+import com.google.common.base.Optional
+
+inline fun <T, G> Optional<T>?.isPresent(block: (obj: T) -> G) : G? {
+    return if (this?.isPresent == true) {
+        block.invoke(get())
+    } else {
+        null
+    }
+}

--- a/app/src/main/java/com/nytimes/android/external/register/Signer.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/Signer.kt
@@ -7,14 +7,15 @@ import java.security.PrivateKey
 import java.security.Signature
 import java.security.SignatureException
 
-class Signer(val privateKey: Optional<PrivateKey>?, val signature: Optional<Signature>?) {
+class Signer(private val privateKey: Optional<PrivateKey>?,
+             private val signature: Optional<Signature>?) {
 
     @Throws(InvalidKeyException::class, SignatureException::class)
     fun signData(unsignedData: String): String {
-        return signature?.isPresent?.let {
-            signature.get().initSign(privateKey?.orNull())
-            signature.get().update(unsignedData.toByteArray(StandardCharsets.UTF_8))
-            String(signature.get().sign(), StandardCharsets.UTF_8)
+        return signature.isPresent {
+            it.initSign(privateKey?.orNull())
+            it.update(unsignedData.toByteArray(StandardCharsets.UTF_8))
+            String(it.sign(), StandardCharsets.UTF_8)
         } ?: ""
     }
 }

--- a/app/src/main/java/com/nytimes/android/external/register/bundle/BuyIntentBundleBuilder.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/bundle/BuyIntentBundleBuilder.kt
@@ -37,8 +37,8 @@ constructor(protected val application: Application, apiOverrides: APIOverrides) 
         return this
     }
 
-    fun developerPayload(developerPayload: String): BuyIntentBundleBuilder {
-        intent.putExtra(EX_DEVELOPER_PAYLOAD, developerPayload)
+    fun developerPayload(developerPayload: String?): BuyIntentBundleBuilder {
+        developerPayload?.let { intent.putExtra(EX_DEVELOPER_PAYLOAD, it) }
         return this
     }
 

--- a/app/src/main/java/com/nytimes/android/external/register/bundle/BuyIntentToReplaceSkusBundleBuilder.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/bundle/BuyIntentToReplaceSkusBundleBuilder.kt
@@ -41,7 +41,7 @@ constructor(protected val application: Application, apiOverrides: APIOverrides) 
         return this
     }
 
-    fun developerPayload(developerPayload: String): BuyIntentToReplaceSkusBundleBuilder {
+    fun developerPayload(developerPayload: String?): BuyIntentToReplaceSkusBundleBuilder {
         intent.putExtra(EX_DEVELOPER_PAYLOAD, developerPayload)
         return this
     }

--- a/app/src/main/java/com/nytimes/android/external/register/bundle/PurchasesBundleBuilder.kt
+++ b/app/src/main/java/com/nytimes/android/external/register/bundle/PurchasesBundleBuilder.kt
@@ -24,7 +24,7 @@ constructor(apiOverrides: APIOverrides, private val purchases: Purchases) : Base
         return this
     }
 
-    fun continuationToken(continuationToken: String): PurchasesBundleBuilder {
+    fun continuationToken(continuationToken: String?): PurchasesBundleBuilder {
         this.continuationToken = continuationToken
         return this
     }


### PR DESCRIPTION
Couple of nullability issues was causing purchases to fail.

```
Failed to retrieve products and purchases
 java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter continuationToken
```

```
Process: com.nytimes.android.external.register.sample, PID: 1877
io.reactivex.exceptions.OnErrorNotImplementedException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter developerPayload
```

and finally, added an `Optional.isPresent` extension method. `Signer ` class was checking only nullability of `Optional.isPresent` boolean, not if `Signature` was actually present.

| Companion | Sample |
| --- | --- |
| ![Screenshot_1567469202](https://user-images.githubusercontent.com/3921079/64136209-2c2ae600-cdbe-11e9-9483-2377394502fc.png) | ![Screenshot_1567469197](https://user-images.githubusercontent.com/3921079/64136212-31883080-cdbe-11e9-94ca-1f9709bf6224.png) | 
