### PR TITLE
Update Register Lib and sample to use Play Billing 2.1.0

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -36,7 +36,7 @@ ext.versions = [
         rxJava               : '2.1.0',
         rxAndroid            : '2.0.1',
         retrofit             : '2.3.0',
-        billing              : '1.1',
+        billing              : '2.1.0',
 
         // Kotlin.
         kotlin               : '1.3.21',

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,6 +23,7 @@ android {
 dependencies {
     implementation libraries.billing
     implementation libraries.kotlin
+    implementation libraries.supportAnnotations
 
     testImplementation libraries.junit
     testImplementation libraries.assertJ

--- a/lib/src/main/java/com/android/billingclient/api/BillingClientTesting.kt
+++ b/lib/src/main/java/com/android/billingclient/api/BillingClientTesting.kt
@@ -16,16 +16,35 @@ import java.io.FileDescriptor
  * `com.android.billingclient.api` package, so to have visibility over the
  * [BillingClientImpl] class (which is package-private).
  */
-class BillingClientTesting(context: Context, listener: PurchasesUpdatedListener) : BillingClient() {
+class BillingClientTesting(
+        context: Context,
+        childDirected: Int,
+        underAgeOfConsent: Int,
+        enablePendingPurchases: Boolean,
+        listener: PurchasesUpdatedListener
+
+) : BillingClient() {
 
     private val billingClientImpl: BillingClientImpl =
-            BillingClientImpl(BillingContextWrapper(context), listener)
+            BillingClientImpl(BillingContextWrapper(context), childDirected, underAgeOfConsent, enablePendingPurchases, listener)
+
+    override fun loadRewardedSku(params: RewardLoadParams?, listener: RewardResponseListener) {
+        billingClientImpl.loadRewardedSku(params, listener)
+    }
+
+    override fun acknowledgePurchase(params: AcknowledgePurchaseParams?, listener: AcknowledgePurchaseResponseListener?) {
+        billingClientImpl.acknowledgePurchase(params, listener)
+    }
+
+    override fun launchPriceChangeConfirmationFlow(activity: Activity?, params: PriceChangeFlowParams?, listener: PriceChangeConfirmationListener) {
+        billingClientImpl.launchPriceChangeConfirmationFlow(activity, params, listener)
+    }
 
     override fun isReady(): Boolean {
         return billingClientImpl.isReady
     }
 
-    override fun isFeatureSupported(feature: String): Int {
+    override fun isFeatureSupported(feature: String): BillingResult {
         return billingClientImpl.isFeatureSupported(feature)
     }
 
@@ -37,7 +56,7 @@ class BillingClientTesting(context: Context, listener: PurchasesUpdatedListener)
         billingClientImpl.endConnection()
     }
 
-    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): Int {
+    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
         return billingClientImpl.launchBillingFlow(activity, params)
     }
 
@@ -49,8 +68,8 @@ class BillingClientTesting(context: Context, listener: PurchasesUpdatedListener)
         billingClientImpl.querySkuDetailsAsync(params, listener)
     }
 
-    override fun consumeAsync(purchaseToken: String, listener: ConsumeResponseListener) {
-        billingClientImpl.consumeAsync(purchaseToken, listener)
+    override fun consumeAsync(params: ConsumeParams, listener: ConsumeResponseListener) {
+        billingClientImpl.consumeAsync(params, listener)
     }
 
     override fun queryPurchaseHistoryAsync(skuType: String, listener: PurchaseHistoryResponseListener) {

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProvider.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProvider.kt
@@ -188,6 +188,36 @@ abstract class GoogleServiceProvider {
     abstract fun queryPurchaseHistoryAsync(
             @BillingClient.SkuType skuType: String, listener: PurchaseHistoryResponseListener)
 
+    /**
+     * Acknowledge in-app purchases.
+     *
+     * <p>Developers are required to acknowledge that they have granted entitlement for all in-app
+     * purchases for their application.
+     *
+     * @param params Params specific to this acknowledge purchase request {@link
+     *     AcknowledgePurchaseParams}
+     * @param listener Implement it to get the result of the acknowledge operation returned
+     *     asynchronously through the callback with the {@link BillingResponseCode}
+     */
+    @UiThread
+    abstract fun acknowledgePurchase(params: AcknowledgePurchaseParams, listener: AcknowledgePurchaseResponseListener)
+
+    /**
+     * Loads a rewarded sku in the background and returns the result asynchronously.
+     *
+     *
+     * If the rewarded sku is available, the response will be BILLING_RESULT_OK. Otherwise the
+     * response will be ITEM_UNAVAILABLE. There is no guarantee that a rewarded sku will always be
+     * available. After a successful response, only then should the offer be given to a user to obtain
+     * a rewarded item and call launchBillingFlow.
+     *
+     * @param params Params specific to this load request [RewardLoadParams]
+     * @param listener Implement it to get the result of the load operation returned asynchronously
+     * through the callback with the [BillingResponseCode]
+     */
+    abstract fun loadRewardedSku(
+            params: RewardLoadParams, listener: RewardResponseListener)
+
     companion object {
 
         /**

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProvider.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProvider.kt
@@ -2,7 +2,7 @@ package com.nytimes.android.external.registerlib
 
 import android.app.Activity
 import android.content.Context
-import android.support.annotation.UiThread
+import androidx.annotation.UiThread
 import com.android.billingclient.api.*
 
 /**
@@ -28,6 +28,9 @@ abstract class GoogleServiceProvider {
     class Builder constructor(private val mContext: Context?) {
         private var mListener: PurchasesUpdatedListener? = null
         private var useTestProvider: Boolean = false
+        private var underAgeOfConsent: Int = BillingClient.UnderAgeOfConsent.UNSPECIFIED
+        private var childDirected: Int = BillingClient.ChildDirected.UNSPECIFIED
+        private var enablePendingPurchases: Boolean = false
 
         /**
          * Specify a valid listener for onPurchasesUpdated event.
@@ -43,6 +46,24 @@ abstract class GoogleServiceProvider {
         @UiThread
         fun useTestProvider(useTestProvider: Boolean): GoogleServiceProvider.Builder {
             this.useTestProvider = useTestProvider
+            return this
+        }
+
+        @UiThread
+        fun setUnderAgeOfConsent(underAgeOfConsent: Int): GoogleServiceProvider.Builder {
+            this.underAgeOfConsent = underAgeOfConsent
+            return this
+        }
+
+        @UiThread
+        fun setChildDirected(childDirected: Int): GoogleServiceProvider.Builder {
+            this.childDirected = childDirected
+            return this
+        }
+
+        @UiThread
+        fun enablePendingPurchases(): GoogleServiceProvider.Builder {
+            this.enablePendingPurchases = true
             return this
         }
 
@@ -66,9 +87,9 @@ abstract class GoogleServiceProvider {
             }
 
             return if (useTestProvider) {
-                GoogleServiceProviderTesting(mContext, mListener!!)
+                GoogleServiceProviderTesting(mContext,childDirected, underAgeOfConsent, enablePendingPurchases, mListener!!)
             } else {
-                GoogleServiceProviderImpl(mContext, mListener!!)
+                GoogleServiceProviderImpl(mContext,childDirected, underAgeOfConsent, enablePendingPurchases, mListener!!)
             }
         }
     }
@@ -80,8 +101,7 @@ abstract class GoogleServiceProvider {
      * @return BILLING_RESULT_OK if feature is supported and corresponding error code otherwise.
      */
     @UiThread
-    @BillingClient.BillingResponse
-    abstract fun isFeatureSupported(@BillingClient.FeatureType feature: String): Int
+    abstract fun isFeatureSupported(@BillingClient.FeatureType feature: String): BillingResult
 
     /**
      * Starts up BillingClient setup process asynchronously. You will be notified through the [ ] listener when the setup process is complete.
@@ -109,10 +129,10 @@ abstract class GoogleServiceProvider {
      *
      * @param activity An activity reference from which the billing flow will be launched.
      * @param params Params specific to the request [BillingFlowParams]).
-     * @return int The response code ([BillingClient.BillingResponse]) of launch flow operation.
+     * @return BillingResult The response code ([BillingClient.BillingResponse]) of launch flow operation.
      */
     @UiThread
-    abstract fun launchBillingFlow(activity: Activity, params: BillingFlowParams): Int
+    abstract fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult
 
     /**
      * Get purchases details for all the items bought within your app. This method uses a cache of
@@ -154,7 +174,7 @@ abstract class GoogleServiceProvider {
      * asynchronously through the callback with token and [BillingClient.BillingResponse] parameters.
      */
     @UiThread
-    abstract fun consumeAsync(purchaseToken: String, listener: ConsumeResponseListener)
+    abstract fun consumeAsync(params: ConsumeParams, listener: ConsumeResponseListener)
 
     /**
      * Returns the most recent purchase made by the user for each SKU, even if that purchase is

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderImpl.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderImpl.kt
@@ -4,15 +4,30 @@ import android.app.Activity
 import android.content.Context
 import com.android.billingclient.api.*
 
-class GoogleServiceProviderImpl(context: Context, listener: PurchasesUpdatedListener) : GoogleServiceProvider() {
+class GoogleServiceProviderImpl(
+        context: Context,
+        childDirected: Int,
+        underAgeOfConsent: Int,
+        enablePendingPurchases: Boolean,
+        listener: PurchasesUpdatedListener
+) : GoogleServiceProvider() {
 
-    private val billingClient: BillingClient = BillingClient.newBuilder(context)
-            .setListener(listener)
-            .build()
+    private val billingClient: BillingClient by lazy {
+        val builder = BillingClient.newBuilder(context)
+                .setListener(listener)
+                .setChildDirected(childDirected)
+                .setUnderAgeOfConsent(underAgeOfConsent)
+
+        if (enablePendingPurchases) {
+            builder.enablePendingPurchases()
+        }
+
+        builder.build()
+    }
 
     override fun isReady(): Boolean = billingClient.isReady
 
-    override fun isFeatureSupported(feature: String): Int {
+    override fun isFeatureSupported(feature: String): BillingResult {
         return billingClient.isFeatureSupported(feature)
     }
 
@@ -24,7 +39,7 @@ class GoogleServiceProviderImpl(context: Context, listener: PurchasesUpdatedList
         billingClient.endConnection()
     }
 
-    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): Int {
+    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
         return billingClient.launchBillingFlow(activity, params)
     }
 
@@ -36,8 +51,8 @@ class GoogleServiceProviderImpl(context: Context, listener: PurchasesUpdatedList
         billingClient.querySkuDetailsAsync(params, listener)
     }
 
-    override fun consumeAsync(purchaseToken: String, listener: ConsumeResponseListener) {
-        billingClient.consumeAsync(purchaseToken, listener)
+    override fun consumeAsync(params: ConsumeParams, listener: ConsumeResponseListener) {
+        billingClient.consumeAsync(params, listener)
     }
 
     override fun queryPurchaseHistoryAsync(skuType: String, listener: PurchaseHistoryResponseListener) {

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderImpl.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderImpl.kt
@@ -58,4 +58,12 @@ class GoogleServiceProviderImpl(
     override fun queryPurchaseHistoryAsync(skuType: String, listener: PurchaseHistoryResponseListener) {
         billingClient.queryPurchaseHistoryAsync(skuType, listener)
     }
+
+    override fun acknowledgePurchase(params: AcknowledgePurchaseParams, listener: AcknowledgePurchaseResponseListener) {
+        billingClient.acknowledgePurchase(params, listener)
+    }
+
+    override fun loadRewardedSku(params: RewardLoadParams, listener: RewardResponseListener) {
+        billingClient.loadRewardedSku(params, listener)
+    }
 }

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderTesting.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderTesting.kt
@@ -2,18 +2,30 @@ package com.nytimes.android.external.registerlib
 
 import android.app.Activity
 import android.content.Context
-import android.support.annotation.UiThread
+import androidx.annotation.UiThread
 import com.android.billingclient.api.*
 
-class GoogleServiceProviderTesting(context: Context, listener: PurchasesUpdatedListener) : GoogleServiceProvider() {
+class GoogleServiceProviderTesting(
+        context: Context,
+        childDirected: Int,
+        underAgeOfConsent: Int,
+        enablePendingPurchases: Boolean,
+        listener: PurchasesUpdatedListener
+) : GoogleServiceProvider() {
 
-    private val billingClient: BillingClientTesting = BillingClientTesting(context, listener)
+    private val billingClient: BillingClientTesting = BillingClientTesting(
+            context,
+            childDirected,
+            underAgeOfConsent,
+            enablePendingPurchases,
+            listener
+    )
 
     override fun isReady(): Boolean {
         return billingClient.isReady
     }
 
-    override fun isFeatureSupported(feature: String): Int {
+    override fun isFeatureSupported(feature: String): BillingResult {
         return billingClient.isFeatureSupported(feature)
     }
 
@@ -25,7 +37,7 @@ class GoogleServiceProviderTesting(context: Context, listener: PurchasesUpdatedL
         billingClient.endConnection()
     }
 
-    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): Int {
+    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult {
         return billingClient.launchBillingFlow(activity, params)
     }
 
@@ -37,8 +49,8 @@ class GoogleServiceProviderTesting(context: Context, listener: PurchasesUpdatedL
         billingClient.querySkuDetailsAsync(params, listener)
     }
 
-    override fun consumeAsync(purchaseToken: String, listener: ConsumeResponseListener) {
-        billingClient.consumeAsync(purchaseToken, listener)
+    override fun consumeAsync(params: ConsumeParams, listener: ConsumeResponseListener) {
+        billingClient.consumeAsync(params, listener)
     }
 
     override fun queryPurchaseHistoryAsync(skuType: String, listener: PurchaseHistoryResponseListener) {

--- a/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderTesting.kt
+++ b/lib/src/main/java/com/nytimes/android/external/registerlib/GoogleServiceProviderTesting.kt
@@ -57,6 +57,14 @@ class GoogleServiceProviderTesting(
         billingClient.queryPurchaseHistoryAsync(skuType, listener)
     }
 
+    override fun acknowledgePurchase(params: AcknowledgePurchaseParams, listener: AcknowledgePurchaseResponseListener) {
+        billingClient.acknowledgePurchase(params, listener)
+    }
+
+    override fun loadRewardedSku(params: RewardLoadParams, listener: RewardResponseListener) {
+        billingClient.loadRewardedSku(params, listener)
+    }
+
     companion object {
 
         /**

--- a/sampleApp/src/main/java/com/nytimes/android/external/register/sample/SampleActivity.kt
+++ b/sampleApp/src/main/java/com/nytimes/android/external/register/sample/SampleActivity.kt
@@ -246,7 +246,6 @@ class SampleActivity : AppCompatActivity(), CompoundButton.OnCheckedChangeListen
             val params = BillingFlowParams
                     .newBuilder()
                     .setSkuDetails(skuMap[item.sku])
-//                    .setType(item.type)
                     .build()
             googleServiceProvider.launchBillingFlow(this, params)
         })


### PR DESCRIPTION
Updates to use Google Play Billing Library 2.1.0. Only thing notable in terms of changes is that there are extra methods that we have to call and changed parameters. Otherwise, not too big.